### PR TITLE
Preference overhaul

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,8 +93,6 @@ dependencies {
     implementation("com.google.dagger:hilt-android:2.44.2")
     kapt("com.google.dagger:hilt-compiler:2.44.2")
 
-    implementation("androidx.datastore:datastore-preferences:1.0.0")
-
     implementation("androidx.preference:preference-ktx:1.2.0")
 
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")

--- a/app/src/main/java/dev/bartuzen/qbitcontroller/App.kt
+++ b/app/src/main/java/dev/bartuzen/qbitcontroller/App.kt
@@ -20,7 +20,7 @@ class App : Application() {
         super.onCreate()
 
         CoroutineScope(Dispatchers.Main).launch {
-            settingsManager.themeFlow.collectLatest { theme ->
+            settingsManager.theme.flow.collectLatest { theme ->
                 AppCompatDelegate.setDefaultNightMode(theme.toDelegate())
             }
         }

--- a/app/src/main/java/dev/bartuzen/qbitcontroller/data/ServerManager.kt
+++ b/app/src/main/java/dev/bartuzen/qbitcontroller/data/ServerManager.kt
@@ -1,0 +1,106 @@
+package dev.bartuzen.qbitcontroller.data
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.bartuzen.qbitcontroller.model.Protocol
+import dev.bartuzen.qbitcontroller.model.ServerConfig
+import dev.bartuzen.qbitcontroller.network.RequestManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ServerManager @Inject constructor(
+    @ApplicationContext context: Context,
+    private val requestManager: RequestManager
+) {
+    private val sharedPref = context.getSharedPreferences("servers", Context.MODE_PRIVATE)
+
+    private val mapper = jacksonObjectMapper()
+
+    private fun getServerConfigs() = mapper.readValue<ServerConfigMap>(
+        sharedPref.getString(Keys.SERVER_CONFIGS, null) ?: "{}"
+    )
+
+    private val _serversFlow = MutableStateFlow(getServerConfigs())
+    val serversFlow = _serversFlow.asStateFlow()
+
+    private val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        if (key == Keys.SERVER_CONFIGS) {
+            _serversFlow.value = getServerConfigs()
+        }
+    }
+
+    init {
+        sharedPref.registerOnSharedPreferenceChangeListener(listener)
+    }
+
+    private fun editServerMap(serverConfigsJson: String, block: (ServerConfigMap) -> Unit): String {
+        val mapper = jacksonObjectMapper()
+        val serverConfigs = mapper.readValue<ServerConfigMap>(serverConfigsJson)
+        block(serverConfigs)
+        return mapper.writeValueAsString(serverConfigs)
+    }
+
+    fun addServer(
+        name: String?,
+        protocol: Protocol,
+        host: String,
+        port: Int?,
+        path: String?,
+        username: String,
+        password: String
+    ) {
+        val serverConfigsJson = sharedPref.getString(Keys.SERVER_CONFIGS, null) ?: "{}"
+        val serverId = sharedPref.getInt(Keys.LAST_SERVER_ID, -1) + 1
+
+        val serverConfig =
+            ServerConfig(serverId, name, protocol, host, port, path, username, password)
+
+        val newServerConfigsJson = editServerMap(serverConfigsJson) { serverConfigs ->
+            serverConfigs[serverId] = serverConfig
+        }
+
+        sharedPref.edit()
+            .putString(Keys.SERVER_CONFIGS, newServerConfigsJson)
+            .putInt(Keys.LAST_SERVER_ID, serverId)
+            .apply()
+    }
+
+    fun editServer(serverConfig: ServerConfig) {
+        val serverConfigsJson = sharedPref.getString(Keys.SERVER_CONFIGS, null) ?: "{}"
+
+        val newServerConfigsJson = editServerMap(serverConfigsJson) { serverConfigs ->
+            serverConfigs[serverConfig.id] = serverConfig
+        }
+
+        sharedPref.edit()
+            .putString(Keys.SERVER_CONFIGS, newServerConfigsJson)
+            .apply()
+
+        requestManager.removeTorrentService(serverConfig)
+    }
+
+    fun removeServer(serverConfig: ServerConfig) {
+        val serverConfigsJson = sharedPref.getString(Keys.SERVER_CONFIGS, null) ?: "{}"
+
+        val newServerConfigsJson = editServerMap(serverConfigsJson) { serverConfigs ->
+            serverConfigs.remove(serverConfig.id)
+        }
+
+        sharedPref.edit()
+            .putString(Keys.SERVER_CONFIGS, newServerConfigsJson)
+            .apply()
+
+        requestManager.removeTorrentService(serverConfig)
+    }
+
+    private object Keys {
+        const val SERVER_CONFIGS = "serverConfigs"
+        const val LAST_SERVER_ID = "lastServerId"
+    }
+}

--- a/app/src/main/java/dev/bartuzen/qbitcontroller/data/SettingsManager.kt
+++ b/app/src/main/java/dev/bartuzen/qbitcontroller/data/SettingsManager.kt
@@ -2,146 +2,24 @@ package dev.bartuzen.qbitcontroller.data
 
 import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.emptyPreferences
-import androidx.datastore.preferences.core.intPreferencesKey
-import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import dagger.hilt.android.qualifiers.ApplicationContext
-import dev.bartuzen.qbitcontroller.model.Protocol
 import dev.bartuzen.qbitcontroller.model.ServerConfig
-import dev.bartuzen.qbitcontroller.network.RequestManager
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.map
-import java.io.IOException
+import dev.bartuzen.qbitcontroller.utils.sharedpreferences.enumPreference
+import dev.bartuzen.qbitcontroller.utils.sharedpreferences.primitivePreference
 import java.util.SortedMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
-val Context.dataStore: DataStore<Preferences> by preferencesDataStore("settings")
-
 @Singleton
 class SettingsManager @Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val requestManager: RequestManager
+    @ApplicationContext context: Context
 ) {
-    private val dataStore = context.dataStore
+    private val sharedPref = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
 
-    val themeFlow = getFromDataStore { settings ->
-        Theme.valueOf(settings[PreferenceKeys.THEME] ?: Theme.SYSTEM_DEFAULT.name)
-    }
-
-    val sortFlow = getFromDataStore { settings ->
-        TorrentSort.valueOf(settings[PreferenceKeys.TORRENT_SORT] ?: TorrentSort.NAME.name)
-    }
-
-    val isReverseSortingFlow = getFromDataStore { settings ->
-        settings[PreferenceKeys.IS_REVERSE_SORTING] ?: false
-    }
-
-    val serversFlow = getFromDataStore { settings ->
-        val serverConfigsJson =
-            settings[PreferenceKeys.SERVER_CONFIGS] ?: return@getFromDataStore sortedMapOf()
-
-        val mapper = jacksonObjectMapper()
-        mapper.readValue<ServerConfigMap>(serverConfigsJson)
-    }
-
-    private fun <T> getFromDataStore(block: (Preferences) -> T) =
-        dataStore.data
-            .catch { exception ->
-                if (exception is IOException) {
-                    emit(emptyPreferences())
-                } else {
-                    throw exception
-                }
-            }.map { settings ->
-                block(settings)
-            }
-
-    private fun editServerMap(serverConfigsJson: String, block: (ServerConfigMap) -> Unit): String {
-        val mapper = jacksonObjectMapper()
-        val serverConfigs = mapper.readValue<ServerConfigMap>(serverConfigsJson)
-        block(serverConfigs)
-        return mapper.writeValueAsString(serverConfigs)
-    }
-
-    suspend fun addServer(
-        name: String?,
-        protocol: Protocol,
-        host: String,
-        port: Int?,
-        path: String?,
-        username: String,
-        password: String
-    ) {
-        dataStore.edit { settings ->
-            val serverConfigsJson = settings[PreferenceKeys.SERVER_CONFIGS] ?: "{}"
-            val serverId = (settings[PreferenceKeys.LAST_SERVER_ID] ?: -1) + 1
-
-            val serverConfig =
-                ServerConfig(serverId, name, protocol, host, port, path, username, password)
-
-            val newServerConfigsJson = editServerMap(serverConfigsJson) { serverConfigs ->
-                serverConfigs[serverId] = serverConfig
-            }
-
-            settings[PreferenceKeys.LAST_SERVER_ID] = serverId
-            settings[PreferenceKeys.SERVER_CONFIGS] = newServerConfigsJson
-        }
-    }
-
-    suspend fun editServer(serverConfig: ServerConfig) {
-        dataStore.edit { settings ->
-            val serverConfigsJson = settings[PreferenceKeys.SERVER_CONFIGS] ?: "{}"
-
-            val newServerConfigsJson = editServerMap(serverConfigsJson) { serverConfigs ->
-                serverConfigs[serverConfig.id] = serverConfig
-            }
-
-            settings[PreferenceKeys.SERVER_CONFIGS] = newServerConfigsJson
-        }
-        requestManager.removeTorrentService(serverConfig)
-    }
-
-    suspend fun removeServer(serverConfig: ServerConfig) {
-        dataStore.edit { settings ->
-            val serverConfigsJson = settings[PreferenceKeys.SERVER_CONFIGS] ?: return@edit
-
-            val newServerConfigsJson = editServerMap(serverConfigsJson) { serverConfigs ->
-                serverConfigs.remove(serverConfig.id)
-            }
-
-            settings[PreferenceKeys.SERVER_CONFIGS] = newServerConfigsJson
-        }
-        requestManager.removeTorrentService(serverConfig)
-    }
-
-    suspend fun setTorrentSort(torrentSort: TorrentSort) {
-        dataStore.edit { settings ->
-            settings[PreferenceKeys.TORRENT_SORT] = torrentSort.name
-        }
-    }
-
-    suspend fun setIsReverseSorting(isReversed: Boolean) {
-        dataStore.edit { settings ->
-            settings[PreferenceKeys.IS_REVERSE_SORTING] = isReversed
-        }
-    }
-
-    private object PreferenceKeys {
-        val THEME = stringPreferencesKey("theme")
-        val SERVER_CONFIGS = stringPreferencesKey("server_configs")
-        val LAST_SERVER_ID = intPreferencesKey("last_server_id")
-        val TORRENT_SORT = stringPreferencesKey("sort")
-        val IS_REVERSE_SORTING = booleanPreferencesKey("is_sort_reversed")
-    }
+    val theme = enumPreference(sharedPref, "theme", Theme.SYSTEM_DEFAULT, Theme::valueOf)
+    val sort = enumPreference(sharedPref, "sort", TorrentSort.NAME, TorrentSort::valueOf)
+    val isReverseSorting = primitivePreference(sharedPref, "isReverseSorting", false)
 }
 
 typealias ServerConfigMap = SortedMap<Int, ServerConfig>

--- a/app/src/main/java/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentActivity.kt
+++ b/app/src/main/java/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentActivity.kt
@@ -29,8 +29,6 @@ import dev.bartuzen.qbitcontroller.utils.launchAndCollectLatestIn
 import dev.bartuzen.qbitcontroller.utils.showSnackbar
 import dev.bartuzen.qbitcontroller.utils.showToast
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import kotlin.math.roundToInt
 
 @AndroidEntryPoint
@@ -56,7 +54,7 @@ class AddTorrentActivity : AppCompatActivity() {
         if (serverConfigFromIntent != null) {
             serverConfig = serverConfigFromIntent
         } else {
-            val servers = runBlocking { viewModel.serversFlow.first().values.toList() }
+            val servers = viewModel.getServers()
 
             if (servers.isEmpty()) {
                 showToast(R.string.torrent_add_no_server)

--- a/app/src/main/java/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentViewModel.kt
+++ b/app/src/main/java/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import dev.bartuzen.qbitcontroller.data.SettingsManager
+import dev.bartuzen.qbitcontroller.data.ServerManager
 import dev.bartuzen.qbitcontroller.data.repositories.AddTorrentRepository
 import dev.bartuzen.qbitcontroller.model.ServerConfig
 import dev.bartuzen.qbitcontroller.network.RequestError
@@ -28,12 +28,10 @@ import javax.inject.Inject
 class AddTorrentViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val repository: AddTorrentRepository,
-    settingsManager: SettingsManager
+    private val serverManager: ServerManager
 ) : ViewModel() {
     private val eventChannel = Channel<Event>()
     val eventFlow = eventChannel.receiveAsFlow()
-
-    val serversFlow = settingsManager.serversFlow
 
     private val _categoryList = MutableStateFlow<List<String>?>(null)
     val categoryList = _categoryList.asStateFlow()
@@ -51,6 +49,8 @@ class AddTorrentViewModel @Inject constructor(
     val isCreating = _isCreating.asStateFlow()
 
     var isInitialLoadStarted = false
+
+    fun getServers() = serverManager.serversFlow.value.values.toList()
 
     fun createTorrent(
         serverConfig: ServerConfig,

--- a/app/src/main/java/dev/bartuzen/qbitcontroller/ui/main/MainActivity.kt
+++ b/app/src/main/java/dev/bartuzen/qbitcontroller/ui/main/MainActivity.kt
@@ -109,7 +109,7 @@ class MainActivity : AppCompatActivity() {
             startActivity(intent)
         }
 
-        viewModel.serverList.launchAndCollectLatestIn(this) { serverList ->
+        viewModel.serversFlow.launchAndCollectLatestIn(this) { serverList ->
             serverListAdapter.submitList(serverList.values.toList())
 
             binding.textClickToAddServer.visibility =

--- a/app/src/main/java/dev/bartuzen/qbitcontroller/ui/main/MainViewModel.kt
+++ b/app/src/main/java/dev/bartuzen/qbitcontroller/ui/main/MainViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dev.bartuzen.qbitcontroller.data.SettingsManager
+import dev.bartuzen.qbitcontroller.data.ServerManager
 import dev.bartuzen.qbitcontroller.model.ServerConfig
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -13,11 +13,11 @@ import javax.inject.Inject
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val state: SavedStateHandle,
-    settingsManager: SettingsManager
+    serverManager: ServerManager
 ) : ViewModel() {
     val currentServer = state.getStateFlow<ServerConfig?>("current_server", null)
 
-    val serverList = settingsManager.serversFlow
+    val serversFlow = serverManager.serversFlow
 
     fun setCurrentServer(serverConfig: ServerConfig) {
         state["current_server"] = serverConfig
@@ -25,7 +25,7 @@ class MainViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            serverList.collectLatest { serverList ->
+            serversFlow.collectLatest { serverList ->
                 val currentServerId = currentServer.value?.id ?: -1
                 val firstServer = try {
                     serverList[serverList.firstKey()]

--- a/app/src/main/java/dev/bartuzen/qbitcontroller/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/dev/bartuzen/qbitcontroller/ui/settings/SettingsFragment.kt
@@ -1,40 +1,26 @@
 package dev.bartuzen.qbitcontroller.ui.settings
 
 import android.os.Bundle
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.fragment.app.commit
 import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
 import androidx.preference.ListPreference
-import androidx.preference.PreferenceDataStore
 import androidx.preference.PreferenceFragmentCompat
 import dagger.hilt.android.AndroidEntryPoint
 import dev.bartuzen.qbitcontroller.R
-import dev.bartuzen.qbitcontroller.data.dataStore
 import dev.bartuzen.qbitcontroller.ui.settings.addeditserver.AddEditServerFragment
 import dev.bartuzen.qbitcontroller.ui.settings.addeditserver.AddEditServerFragmentBuilder
 import dev.bartuzen.qbitcontroller.utils.getSerializableCompat
 import dev.bartuzen.qbitcontroller.utils.preferences
 import dev.bartuzen.qbitcontroller.utils.requireAppCompatActivity
 import dev.bartuzen.qbitcontroller.utils.showSnackbar
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 @AndroidEntryPoint
 class SettingsFragment : PreferenceFragmentCompat() {
     private val viewModel: SettingsViewModel by viewModels()
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
-        preferenceManager.preferenceDataStore =
-            SettingsDataStore(preferenceManager.context.dataStore)
-
+        preferenceManager.sharedPreferencesName = "settings"
         initSettings()
 
         setFragmentResultListener("addEditServerResult") { _, bundle ->
@@ -120,31 +106,6 @@ class SettingsFragment : PreferenceFragmentCompat() {
             entries = resources.getStringArray(R.array.settings_theme_entries)
             entryValues = arrayOf("LIGHT", "DARK", "SYSTEM_DEFAULT")
             setDefaultValue("SYSTEM_DEFAULT")
-        }
-    }
-
-    class SettingsDataStore(private val dataStore: DataStore<Preferences>) : PreferenceDataStore() {
-
-        override fun putString(key: String, value: String?) {
-            CoroutineScope(Dispatchers.IO).launch {
-                dataStore.edit {
-                    it[stringPreferencesKey(key)] = value!!
-                }
-            }
-        }
-
-        override fun getString(key: String, defValue: String?) = runBlocking {
-            dataStore.data.map {
-                val pref = it[stringPreferencesKey(key)]
-                if (pref != null) {
-                    pref
-                } else {
-                    dataStore.edit { settings ->
-                        settings[stringPreferencesKey(key)] = defValue!!
-                    }
-                    defValue!!
-                }
-            }.first()
         }
     }
 

--- a/app/src/main/java/dev/bartuzen/qbitcontroller/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/dev/bartuzen/qbitcontroller/ui/settings/SettingsViewModel.kt
@@ -2,16 +2,12 @@ package dev.bartuzen.qbitcontroller.ui.settings
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dev.bartuzen.qbitcontroller.data.SettingsManager
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import dev.bartuzen.qbitcontroller.data.ServerManager
 import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
-    private val settingsManager: SettingsManager
+    private val serverManager: ServerManager
 ) : ViewModel() {
-    fun getServers() = runBlocking {
-        settingsManager.serversFlow.first()
-    }
+    fun getServers() = serverManager.serversFlow.value
 }

--- a/app/src/main/java/dev/bartuzen/qbitcontroller/ui/settings/addeditserver/AddEditServerViewModel.kt
+++ b/app/src/main/java/dev/bartuzen/qbitcontroller/ui/settings/addeditserver/AddEditServerViewModel.kt
@@ -3,7 +3,7 @@ package dev.bartuzen.qbitcontroller.ui.settings.addeditserver
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dev.bartuzen.qbitcontroller.data.SettingsManager
+import dev.bartuzen.qbitcontroller.data.ServerManager
 import dev.bartuzen.qbitcontroller.model.Protocol
 import dev.bartuzen.qbitcontroller.model.ServerConfig
 import kotlinx.coroutines.launch
@@ -11,7 +11,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AddEditServerViewModel @Inject constructor(
-    private val settingsManager: SettingsManager
+    private val serverManager: ServerManager
 ) : ViewModel() {
     fun addServer(
         name: String?,
@@ -22,14 +22,14 @@ class AddEditServerViewModel @Inject constructor(
         username: String,
         password: String
     ) = viewModelScope.launch {
-        settingsManager.addServer(name, protocol, host, port, path, username, password)
+        serverManager.addServer(name, protocol, host, port, path, username, password)
     }
 
     fun editServer(serverConfig: ServerConfig) = viewModelScope.launch {
-        settingsManager.editServer(serverConfig)
+        serverManager.editServer(serverConfig)
     }
 
     fun removeServer(serverConfig: ServerConfig) = viewModelScope.launch {
-        settingsManager.removeServer(serverConfig)
+        serverManager.removeServer(serverConfig)
     }
 }

--- a/app/src/main/java/dev/bartuzen/qbitcontroller/ui/torrentlist/TorrentListFragment.kt
+++ b/app/src/main/java/dev/bartuzen/qbitcontroller/ui/torrentlist/TorrentListFragment.kt
@@ -152,44 +152,41 @@ class TorrentListFragment : ArgsFragment(R.layout.fragment_torrent_list) {
                     true
                 }
                 R.id.menu_sort_name -> {
-                    viewModel.setTorrentSort(TorrentSort.NAME).invokeOnCompletion {
-                        viewModel.loadTorrentList(serverConfig)
-                    }
+                    viewModel.setTorrentSort(TorrentSort.NAME)
                     true
                 }
                 R.id.menu_sort_hash -> {
-                    viewModel.setTorrentSort(TorrentSort.HASH).invokeOnCompletion {
-                        viewModel.loadTorrentList(serverConfig)
-                    }
+                    viewModel.setTorrentSort(TorrentSort.HASH)
                     true
                 }
                 R.id.menu_sort_dlspeed -> {
-                    viewModel.setTorrentSort(TorrentSort.DOWNLOAD_SPEED).invokeOnCompletion {
-                        viewModel.loadTorrentList(serverConfig)
-                    }
+                    viewModel.setTorrentSort(TorrentSort.DOWNLOAD_SPEED)
                     true
                 }
                 R.id.menu_sort_upspeed -> {
-                    viewModel.setTorrentSort(TorrentSort.UPLOAD_SPEED).invokeOnCompletion {
-                        viewModel.loadTorrentList(serverConfig)
-                    }
+                    viewModel.setTorrentSort(TorrentSort.UPLOAD_SPEED)
                     true
                 }
                 R.id.menu_sort_priority -> {
-                    viewModel.setTorrentSort(TorrentSort.PRIORITY).invokeOnCompletion {
-                        viewModel.loadTorrentList(serverConfig)
-                    }
+                    viewModel.setTorrentSort(TorrentSort.PRIORITY)
                     true
                 }
                 R.id.menu_sort_reverse -> {
-                    viewModel.changeReverseSorting().invokeOnCompletion {
-                        viewModel.loadTorrentList(serverConfig)
-                    }
+                    viewModel.changeReverseSorting()
                     true
                 }
                 else -> false
             }
         }, viewLifecycleOwner)
+
+        combine(
+            viewModel.torrentSort,
+            viewModel.isReverseSorting
+        ) { _, _ ->
+
+        }.launchAndCollectLatestIn(viewLifecycleOwner) {
+            viewModel.loadTorrentList(serverConfig)
+        }
 
         var actionMode: ActionMode? = null
         val adapter = TorrentListAdapter().apply {
@@ -366,7 +363,6 @@ class TorrentListFragment : ArgsFragment(R.layout.fragment_torrent_list) {
 
         if (!viewModel.isInitialLoadStarted) {
             viewModel.isInitialLoadStarted = true
-            viewModel.loadTorrentList(serverConfig)
             viewModel.updateCategoryAndTags(serverConfig)
         }
 

--- a/app/src/main/java/dev/bartuzen/qbitcontroller/utils/sharedpreferences/EnumPreference.kt
+++ b/app/src/main/java/dev/bartuzen/qbitcontroller/utils/sharedpreferences/EnumPreference.kt
@@ -1,0 +1,41 @@
+package dev.bartuzen.qbitcontroller.utils.sharedpreferences
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class EnumPreference<T : Enum<*>>(
+    private val sharedPref: SharedPreferences,
+    private val key: String,
+    private val initialValue: T,
+    private val factory: (String) -> T
+) {
+    var value: T
+        get() {
+            val enumString = sharedPref.getString(key, null)
+            return if (enumString != null) factory(enumString) else initialValue
+        }
+        set(value) {
+            sharedPref.edit()
+                .putString(key, value.name)
+                .apply()
+        }
+
+    val flow = MutableStateFlow(value)
+
+    private val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        if (key == this.key) {
+            flow.value = value
+        }
+    }
+
+    init {
+        sharedPref.registerOnSharedPreferenceChangeListener(listener)
+    }
+}
+
+fun <T : Enum<*>> enumPreference(
+    sharedPref: SharedPreferences,
+    key: String,
+    initialValue: T,
+    factory: (String) -> T
+) = EnumPreference(sharedPref, key, initialValue, factory)

--- a/app/src/main/java/dev/bartuzen/qbitcontroller/utils/sharedpreferences/PrimitivePreference.kt
+++ b/app/src/main/java/dev/bartuzen/qbitcontroller/utils/sharedpreferences/PrimitivePreference.kt
@@ -1,0 +1,77 @@
+package dev.bartuzen.qbitcontroller.utils.sharedpreferences
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlin.reflect.KClass
+
+@Suppress("UNCHECKED_CAST")
+class PrimitivePreference<T : Any>(
+    private val sharedPref: SharedPreferences,
+    private val key: String,
+    private val initialValue: T,
+    private val type: KClass<T>
+) {
+    var value: T
+        get() = when (type) {
+            Int::class -> {
+                sharedPref.getInt(key, initialValue as Int) as T
+            }
+            Boolean::class -> {
+                sharedPref.getBoolean(key, initialValue as Boolean) as T
+            }
+            Float::class -> {
+                sharedPref.getFloat(key, initialValue as Float) as T
+            }
+            Long::class -> {
+                sharedPref.getLong(key, initialValue as Long) as T
+            }
+            String::class -> {
+                sharedPref.getString(key, initialValue as String) as T
+            }
+            else -> {
+                throw UnsupportedOperationException("${type.simpleName} is not supported in PrimitivePreference")
+            }
+        }
+        set(value) {
+            val editor = sharedPref.edit()
+            when (type) {
+                Int::class -> {
+                    editor.putInt(key, value as Int) as T
+                }
+                Boolean::class -> {
+                    editor.putBoolean(key, value as Boolean) as T
+                }
+                Float::class -> {
+                    editor.putFloat(key, value as Float) as T
+                }
+                Long::class -> {
+                    editor.putLong(key, value as Long) as T
+                }
+                String::class -> {
+                    editor.putString(key, value as String) as T
+                }
+                else -> {
+                    throw UnsupportedOperationException("${type.simpleName} is not supported in PrimitivePreference")
+                }
+            }
+            editor.apply()
+        }
+
+    val flow = MutableStateFlow(value)
+
+    private val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        if (key == this.key) {
+            flow.value = value
+        }
+    }
+
+    init {
+        sharedPref.registerOnSharedPreferenceChangeListener(listener)
+    }
+}
+
+inline fun <reified T : Any> primitivePreference(
+    sharedPref: SharedPreferences,
+    key: String,
+    initialValue: T
+) = PrimitivePreference(sharedPref, key, initialValue, T::class)


### PR DESCRIPTION
This PR migrates DataStore to SharedPreferences since DataStore does not fulfill this projects needs, and puts server managing logic into another class to reduce complexity of SettingsManager.

Reverted old PR since there are still issues related to synchronization.