### PR TITLE
Do not ignore set-cookie from other endpoints besides `login`

### DIFF
--- a/app/src/main/java/dev/bartuzen/qbitcontroller/network/SessionCookieJar.kt
+++ b/app/src/main/java/dev/bartuzen/qbitcontroller/network/SessionCookieJar.kt
@@ -8,9 +8,7 @@ class SessionCookieJar : CookieJar {
     private var cookies: List<Cookie>? = null
 
     override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
-        if (url.encodedPath.endsWith("login")) {
-            this.cookies = cookies
-        }
+        this.cookies = cookies
     }
 
     override fun loadForRequest(url: HttpUrl) = if (!url.encodedPath.endsWith("login")) {


### PR DESCRIPTION
Fixes: https://github.com/Bartuzen/qBitController/issues/182

It looks like the search results endpoint is dependent on the current user session ID (SID cookie). I confirmed this with the following repro steps in the qBittorrent WEB UI:

1. Started a session and got a unique SID cookie
2. Called `search/start` endpoint and obtained a search result ID
3. Started a new session with a different SID from step 1
4. Called `search/results` with the search result ID obtained from step 2 (results in 404)
5. Called `search/results` with SID from step 1 and search result ID from step 2 (results in 200, and results returned)

Since the SessionCookieJar is responsible for setting this cookie (which was missing from the search requests from the app in my testing) I took a look further. The SID cookie is only set when `login` is called. The issue with this is that I noticed that unless a user explicitly clicks "test" after adding a server, the login endpoint may not get called. I was not able to confirm if `login` is called when initially starting the app but I suspect that it may not be (which would not set an SID and would, in turn, cause the same search 404 behavior).

Repro steps for below screenshot -
1. Add a server
2. Click save (purposefully do not click test)

Observations:
1. `version` endpoint actually has a set-cookie header (others may as well).
2. When inspecting requests before my fix in Android Studio I noticed that no SID cookie is even sent in the requests (I think this is what results in the search 404 since no SID is present when calling `search/start` and `search/results`)

<img width="1688" alt="image" src="https://github.com/user-attachments/assets/f984586c-7fd4-4302-99f7-fb17986b5cbb" />

I don't see value in dropping the set-cookie headers from other endpoints aside from `login` unless there is some previous bug that this was working around or something. I thought this was a viable solution otherwise since the browser (I'm used to web development) does not normally ignore a set-cookie header.

Other notable things about my environment:
1. qBittorrent client has LAN subnet whitelisted for web ui so it does not require username/password authentication.
2. Jackett is the only enabled search plugin.
3. qBittorrent client is v5.0.3.
4. Using this from my phone now and it seems to work fine after this change.