### PR TITLE
Server path completion for download path on AddTorrentScreen

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/data/repositories/AddTorrentRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/data/repositories/AddTorrentRepository.kt
@@ -92,4 +92,8 @@ class AddTorrentRepository(
     suspend fun getDefaultSavePath(serverId: Int) = requestManager.request(serverId) { service ->
         service.getDefaultSavePath()
     }
+
+    suspend fun getDirectoryContent(serverId: Int, path: String) = requestManager.request(serverId) { service ->
+        service.getDirectoryContent(path)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/di/AppModule.kt
@@ -89,7 +89,7 @@ val appModule = module {
     viewModel { (serverId: Int, hash: String) -> TorrentPeersViewModel(serverId, hash, get(), get(), get()) }
     viewModel { (serverId: Int, hash: String) -> TorrentWebSeedsViewModel(serverId, hash, get(), get()) }
 
-    viewModel { (initialServerId: Int?) -> AddTorrentViewModel(initialServerId, get(), get(), get()) }
+    viewModel { (initialServerId: Int?) -> AddTorrentViewModel(initialServerId, get(), get(), get(), get()) }
 
     viewModel { (serverId: Int) -> RssFeedsViewModel(serverId, get()) }
     viewModel { (serverId: Int, feedPath: List<String>, uid: String?) ->

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/network/TorrentService.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/network/TorrentService.kt
@@ -109,6 +109,11 @@ class TorrentService(
 
     suspend fun getDefaultSavePath(): Response<String> = get("app/defaultSavePath")
 
+    suspend fun getDirectoryContent(path: String): Response<List<String>> = get(
+        "app/getDirectoryContent",
+        mapOf("dirPath" to path),
+    )
+
     suspend fun shutdown(): Response<String> = post("app/shutdown")
 
     suspend fun getLog(): Response<List<Log>> = get("log/main")

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentScreen.kt
@@ -73,7 +73,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -880,7 +882,7 @@ fun AddTorrentScreen(
                 var savePathExpanded by remember { mutableStateOf(false) }
 
                 // Hide suggestions when IME is folded
-                val density = androidx.compose.ui.platform.LocalDensity.current
+                val density = LocalDensity.current
                 val isImeVisible = WindowInsets.ime.getBottom(density) > 0
                 LaunchedEffect(isImeVisible) {
                     if (!isImeVisible) {
@@ -955,7 +957,7 @@ fun AddTorrentScreen(
                                     onClick = {
                                         savePath = TextFieldValue(
                                             text = suggestion,
-                                            selection = androidx.compose.ui.text.TextRange(suggestion.length),
+                                            selection = TextRange(suggestion.length),
                                         )
                                         savePathExpanded = true
                                         // Trigger search again for the new path to load its subdirectories

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentScreen.kt
@@ -921,7 +921,7 @@ fun AddTorrentScreen(
                             onNext = {
                                 savePathExpanded = false
                                 defaultKeyboardAction(ImeAction.Next)
-                            }
+                            },
                         ),
                     )
 
@@ -938,7 +938,9 @@ fun AddTorrentScreen(
                                             text = buildAnnotatedString {
                                                 val matchLength = savePath.text.length
                                                 if (suggestion.startsWith(savePath.text, ignoreCase = true)) {
-                                                    withStyle(style = SpanStyle(background = Color.LightGray.copy(alpha = 0.5f))) {
+                                                    withStyle(
+                                                        style = SpanStyle(background = Color.LightGray.copy(alpha = 0.5f)),
+                                                    ) {
                                                         append(suggestion.take(matchLength))
                                                     }
                                                     append(suggestion.drop(matchLength))

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -32,6 +34,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -68,10 +71,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
@@ -876,6 +879,15 @@ fun AddTorrentScreen(
                 val directorySuggestions by viewModel.directorySuggestions.collectAsStateWithLifecycle()
                 var savePathExpanded by remember { mutableStateOf(false) }
 
+                // Hide suggestions when IME is folded
+                val density = androidx.compose.ui.platform.LocalDensity.current
+                val isImeVisible = WindowInsets.ime.getBottom(density) > 0
+                LaunchedEffect(isImeVisible) {
+                    if (!isImeVisible) {
+                        savePathExpanded = false
+                    }
+                }
+
                 ExposedDropdownMenuBox(
                     expanded = savePathExpanded,
                     onExpandedChange = { savePathExpanded = it },
@@ -905,13 +917,19 @@ fun AddTorrentScreen(
                             keyboardType = KeyboardType.Uri,
                             imeAction = ImeAction.Next,
                         ),
+                        keyboardActions = KeyboardActions(
+                            onNext = {
+                                savePathExpanded = false
+                                defaultKeyboardAction(ImeAction.Next)
+                            }
+                        ),
                     )
 
                     if (directorySuggestions.isNotEmpty()) {
                         ExposedDropdownMenu(
                             expanded = savePathExpanded,
                             onDismissRequest = { savePathExpanded = false },
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier.heightIn(max = 240.dp),
                         ) {
                             directorySuggestions.forEach { suggestion ->
                                 DropdownMenuItem(
@@ -920,7 +938,7 @@ fun AddTorrentScreen(
                                             text = buildAnnotatedString {
                                                 val matchLength = savePath.text.length
                                                 if (suggestion.startsWith(savePath.text, ignoreCase = true)) {
-                                                    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                                                    withStyle(style = SpanStyle(background = Color.LightGray.copy(alpha = 0.5f))) {
                                                         append(suggestion.take(matchLength))
                                                     }
                                                     append(suggestion.drop(matchLength))

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentScreen.kt
@@ -69,10 +69,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -913,7 +917,17 @@ fun AddTorrentScreen(
                                 DropdownMenuItem(
                                     text = {
                                         Text(
-                                            text = suggestion,
+                                            text = buildAnnotatedString {
+                                                val matchLength = savePath.text.length
+                                                if (suggestion.startsWith(savePath.text, ignoreCase = true)) {
+                                                    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                                                        append(suggestion.take(matchLength))
+                                                    }
+                                                    append(suggestion.drop(matchLength))
+                                                } else {
+                                                    append(suggestion)
+                                                }
+                                            },
                                             maxLines = 1,
                                             overflow = TextOverflow.Ellipsis,
                                         )

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentScreen.kt
@@ -911,9 +911,7 @@ fun AddTorrentScreen(
                         onValueChange = {
                             savePath = it
                             savePathExpanded = true
-                            serverId?.let { id ->
-                                viewModel.searchDirectories(id, it.text)
-                            }
+                            viewModel.setSavePath(it.text)
                         },
                         label = {
                             Text(
@@ -972,12 +970,8 @@ fun AddTorrentScreen(
                                             selection = TextRange(suggestion.length),
                                         )
                                         savePathExpanded = true
-                                        // Trigger search again for the new path to load its subdirectories
-                                        serverId?.let { id ->
-                                            viewModel.searchDirectories(id, suggestion)
-                                        }
+                                        viewModel.setSavePath(suggestion)
                                     },
-                                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
                                 )
                             }
                         }

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.bartuzen.qbitcontroller.data.ServerManager
 import dev.bartuzen.qbitcontroller.data.repositories.AddTorrentRepository
+import dev.bartuzen.qbitcontroller.model.Category
 import dev.bartuzen.qbitcontroller.model.QBittorrentVersion
 import dev.bartuzen.qbitcontroller.network.RequestManager
-import dev.bartuzen.qbitcontroller.model.Category
 import dev.bartuzen.qbitcontroller.network.RequestResult
 import dev.bartuzen.qbitcontroller.utils.getSerializableStateFlow
 import io.github.vinceglb.filekit.PlatformFile

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentViewModel.kt
@@ -233,15 +233,23 @@ class AddTorrentViewModel(
             // Debounce
             kotlinx.coroutines.delay(300)
 
-            when (val result = repository.getDirectoryContent(serverId, path)) {
-                is RequestResult.Success -> {
-                    _directorySuggestions.value = result.data.sorted()
-                }
-                is RequestResult.Error -> {
-                    // Ignore errors for suggestions
-                    _directorySuggestions.value = emptyList()
-                }
+            val lastSeparatorIndex = path.lastIndexOfAny(charArrayOf('/', '\\'))
+            val parent = if (lastSeparatorIndex != -1) {
+                path.substring(0, lastSeparatorIndex + 1)
+            } else {
+                ""
             }
+
+            if (parent.isEmpty()) {
+                 _directorySuggestions.value = emptyList()
+                 return@launch
+            }
+
+            val suggestions = repository.getDirectoryContent(serverId, parent)
+            
+            _directorySuggestions.value = suggestions
+                .filter { it.startsWith(path, ignoreCase = true) }
+                .sorted()
         }
     }
 


### PR DESCRIPTION
Inspired by Vuetorrent similar feature: https://github.com/VueTorrent/VueTorrent/pull/2501

Uses [getDirectoryContent API](https://github.com/qbittorrent/qBittorrent/blob/b3ddcacda339af06727660e9cb780d621c2efdfa/src/webui/api/appcontroller.cpp#L1218)

Screenshots: 

<img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/342d1ca2-6fd7-473a-9adf-daba56e0841a" />
<img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/d3486322-1c4d-4006-bdfd-db7f76419b08" />

