### PR TITLE
Fix search result downloads via plugin metadata

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/data/repositories/AddTorrentRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/data/repositories/AddTorrentRepository.kt
@@ -86,17 +86,21 @@ class AddTorrentRepository(
         if (searchLinks != null && version >= QBittorrentVersion(5, 2, 0)) {
             for ((downloader, downloaderLinks) in searchLinks) {
                 for (link in downloaderLinks) {
-                    when (val result = requestManager.request(serverId) { service ->
-                        service.fetchTorrentMetadata(link, downloader)
-                    }) {
+                    when (
+                        val result = requestManager.request(serverId) { service ->
+                            service.fetchTorrentMetadata(link, downloader)
+                        }
+                    ) {
                         is RequestResult.Success -> Unit
                         is RequestResult.Error -> return result
                     }
                 }
 
-                when (val result = requestManager.request(serverId) { service ->
-                    service.addTorrent(buildMultipart(downloaderLinks, downloader))
-                }) {
+                when (
+                    val result = requestManager.request(serverId) { service ->
+                        service.addTorrent(buildMultipart(downloaderLinks, downloader))
+                    }
+                ) {
                     is RequestResult.Success -> {
                         if (result.data == "Fails.") {
                             return result

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/data/repositories/AddTorrentRepository.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/data/repositories/AddTorrentRepository.kt
@@ -16,6 +16,7 @@ class AddTorrentRepository(
     suspend fun addTorrent(
         serverId: Int,
         links: List<String>?,
+        linkDownloaders: List<String>?,
         files: List<Pair<String, ByteArray>>?,
         savePath: String?,
         category: String?,
@@ -39,7 +40,7 @@ class AddTorrentRepository(
             else -> "paused"
         }
 
-        val multipart = MultiPartFormDataContent(
+        fun buildMultipart(links: List<String>?, downloader: String?) = MultiPartFormDataContent(
             formData {
                 files?.forEach { (fileName, byteArray) ->
                     append(
@@ -54,6 +55,7 @@ class AddTorrentRepository(
                 }
 
                 links?.joinToString("\n")?.let { append("urls", it) }
+                downloader?.let { append("downloader", it) }
 
                 append(pausedKey, isPaused.toString())
                 append("skip_checking", skipHashChecking.toString())
@@ -76,8 +78,39 @@ class AddTorrentRepository(
             },
         )
 
+        val searchLinks = links
+            ?.zip(linkDownloaders ?: emptyList())
+            ?.takeIf { it.size == links.size && it.isNotEmpty() }
+            ?.groupBy(keySelector = { it.second }, valueTransform = { it.first })
+
+        if (searchLinks != null && version >= QBittorrentVersion(5, 2, 0)) {
+            for ((downloader, downloaderLinks) in searchLinks) {
+                for (link in downloaderLinks) {
+                    when (val result = requestManager.request(serverId) { service ->
+                        service.fetchTorrentMetadata(link, downloader)
+                    }) {
+                        is RequestResult.Success -> Unit
+                        is RequestResult.Error -> return result
+                    }
+                }
+
+                when (val result = requestManager.request(serverId) { service ->
+                    service.addTorrent(buildMultipart(downloaderLinks, downloader))
+                }) {
+                    is RequestResult.Success -> {
+                        if (result.data == "Fails.") {
+                            return result
+                        }
+                    }
+                    is RequestResult.Error -> return result
+                }
+            }
+
+            return RequestResult.Success("Ok.")
+        }
+
         return requestManager.request(serverId) { service ->
-            service.addTorrent(multipart)
+            service.addTorrent(buildMultipart(links, null))
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/model/Search.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/model/Search.kt
@@ -16,6 +16,8 @@ data class Search(
         @SerialName("descrLink")
         val descriptionLink: String,
 
+        val engineName: String,
+
         val fileName: String,
 
         @Serializable(with = NullableLongSerializer::class)

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/network/TorrentService.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/network/TorrentService.kt
@@ -316,6 +316,11 @@ class TorrentService(
         formData,
     )
 
+    suspend fun fetchTorrentMetadata(source: String, downloader: String): Response<JsonElement> = post(
+        "torrents/fetchMetadata",
+        mapOf("source" to source, "downloader" to downloader),
+    )
+
     suspend fun setAutomaticTorrentManagement(hashes: String, enable: Boolean): Response<Unit> = post(
         "torrents/setAutoManagement",
         mapOf("hashes" to hashes, "enable" to enable),

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentScreen.kt
@@ -169,6 +169,7 @@ fun AddTorrentScreen(
     initialServerId: Int?,
     torrentUrl: String?,
     torrentFileUris: List<String>?,
+    torrentUrlDownloaders: List<String>? = null,
     onNavigateBack: () -> Unit,
     onAddTorrent: (serverId: Int) -> Unit,
     modifier: Modifier = Modifier,
@@ -380,6 +381,7 @@ fun AddTorrentScreen(
         viewModel.addTorrent(
             serverId = currentServerId,
             links = if (isUrlMode) torrentLinkText.text.split("\n") else null,
+            linkDownloaders = if (isUrlMode) torrentUrlDownloaders else null,
             files = if (!isUrlMode) torrentFiles else null,
             savePath = finalSavePath,
             category = selectedCategory,

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/addtorrent/AddTorrentViewModel.kt
@@ -104,6 +104,7 @@ class AddTorrentViewModel(
     fun addTorrent(
         serverId: Int,
         links: List<String>?,
+        linkDownloaders: List<String>?,
         files: List<PlatformFile>?,
         savePath: String?,
         category: String?,
@@ -140,6 +141,7 @@ class AddTorrentViewModel(
                 val result = repository.addTorrent(
                     serverId,
                     links,
+                    linkDownloaders,
                     filesWithContent,
                     savePath,
                     category,

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/main/Destination.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/main/Destination.kt
@@ -18,6 +18,7 @@ sealed class Destination {
         val initialServerId: Int? = null,
         val torrentUrl: String? = null,
         val torrentFileUris: List<String>? = null,
+        val torrentUrlDownloaders: List<String>? = null,
     ) : Destination()
 
     sealed class Rss {

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/search/SearchNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/search/SearchNavHost.kt
@@ -101,8 +101,14 @@ fun SearchNavHost(serverConfig: ServerConfig?, navigateToStartFlow: Flow<Unit>, 
                 plugins = args.plugins,
                 addTorrentFlow = addTorrentChannel.receiveAsFlow(),
                 onNavigateBack = { navController.navigateUp() },
-                onNavigateToAddTorrent = { torrentUrl ->
-                    navController.navigateWithLifecycle(Destination.AddTorrent(args.serverId, torrentUrl))
+                onNavigateToAddTorrent = { torrentUrl, torrentUrlDownloaders ->
+                    navController.navigateWithLifecycle(
+                        Destination.AddTorrent(
+                            initialServerId = args.serverId,
+                            torrentUrl = torrentUrl,
+                            torrentUrlDownloaders = torrentUrlDownloaders,
+                        ),
+                    )
                 },
             )
         }
@@ -121,6 +127,7 @@ fun SearchNavHost(serverConfig: ServerConfig?, navigateToStartFlow: Flow<Unit>, 
                 initialServerId = args.initialServerId,
                 torrentUrl = args.torrentUrl,
                 torrentFileUris = args.torrentFileUris,
+                torrentUrlDownloaders = args.torrentUrlDownloaders,
                 onNavigateBack = { navController.navigateUp() },
                 onAddTorrent = { serverId ->
                     navController.previousBackStackEntry

--- a/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/search/result/SearchResultScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/bartuzen/qbitcontroller/ui/search/result/SearchResultScreen.kt
@@ -186,7 +186,7 @@ fun SearchResultScreen(
     plugins: String,
     addTorrentFlow: Flow<Unit>,
     onNavigateBack: () -> Unit,
-    onNavigateToAddTorrent: (torrentUrl: String) -> Unit,
+    onNavigateToAddTorrent: (torrentUrl: String, torrentUrlDownloaders: List<String>) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SearchResultViewModel =
         koinViewModel(parameters = { parametersOf(serverId, searchQuery, category, plugins) }),
@@ -260,7 +260,7 @@ fun SearchResultScreen(
                 searchResult = dialog.searchResult,
                 onDismiss = { currentDialog = null },
                 onDownload = {
-                    onNavigateToAddTorrent(dialog.searchResult.fileUrl)
+                    onNavigateToAddTorrent(dialog.searchResult.fileUrl, listOf(dialog.searchResult.engineName))
                     currentDialog = null
                 },
                 onOpenDescription = {
@@ -518,10 +518,12 @@ fun SearchResultScreen(
                                 ActionMenuItem(
                                     title = stringResource(Res.string.search_result_action_download),
                                     onClick = {
+                                        val searchResults = selectedTorrents.map {
+                                            Json.decodeFromString<Search.Result>(it)
+                                        }
                                         onNavigateToAddTorrent(
-                                            selectedTorrents.joinToString("\n") {
-                                                Json.decodeFromString<Search.Result>(it).fileUrl
-                                            },
+                                            searchResults.joinToString("\n") { it.fileUrl },
+                                            searchResults.map { it.engineName },
                                         )
                                     },
                                     showAsAction = true,


### PR DESCRIPTION
## Summary

This fixes qBittorrent 5.2.x search-result downloads when a result's `fileUrl` is an HTML page that must be resolved by the search plugin.

Previously qBitController passed search result URLs directly to `/api/v2/torrents/add`, which caused qBittorrent to try to bdecode HTML as a torrent and fail with:

```text
expected value (list, dict, int or string) in bencoded string [bdecode:4]
```

qBittorrent WebUI handles this path by preserving the result's `engineName`, calling `/api/v2/torrents/fetchMetadata` with `source` and `downloader`, and then submitting the original URL to `/api/v2/torrents/add` with the same `downloader`.

This PR mirrors that flow for search-origin torrent adds on qBittorrent 5.2+ while leaving generic URL/file adds unchanged.

## Changes

- Deserialize `engineName` from search results.
- Carry search result downloader names through search navigation into the Add Torrent screen.
- For qBittorrent 5.2+, call `torrents/fetchMetadata` with `source=<fileUrl>` and `downloader=<engineName>` before adding.
- Include `downloader` in the final `torrents/add` multipart form for search-origin URLs.
- Group multi-selected search results by downloader so mixed search plugins are handled correctly.
- Preserve previous direct-add behavior for non-search adds and older qBittorrent versions.

## Tested

- `./gradlew :composeApp:compileKotlinDesktop`
- `./gradlew :composeApp:compileFreeDebugKotlinAndroid`
- `./gradlew :composeApp:assembleFreeDebug`

Built debug APK successfully:

```text
composeApp/build/outputs/apk/free/debug/composeApp-free-debug.apk
```

## AI disclosure

This change was generated with assistance from OpenAI Codex. I reviewed the implementation, compared it against qBittorrent 5.2 WebUI/server source, and verified it with the build commands listed above.
